### PR TITLE
Fail gracefully if ticker message could not be found

### DIFF
--- a/classes/controller/manage.php
+++ b/classes/controller/manage.php
@@ -79,9 +79,10 @@ class Controller_Manage extends \Cms\Controller_Template
 	public function action_delete($id = false)
 	{
 		$redirect_url = \Uri::create('/admin/ticker/manage');
+		$filter_options = ['options' => ['min_range' => 1]];
 
 		// Check if ID is valid
-		if ($id = (int)$id) {
+		if ($id = filter_var($id, FILTER_VALIDATE_INT, $filter_options)) {
 			// Fetch the ticker message
 			$message = \Ticker\Model_Message::find($id);
 
@@ -92,8 +93,11 @@ class Controller_Manage extends \Cms\Controller_Template
 					\Session::set_flash('success', 'Message deleted');
 				}
 				catch (\Exception $e) {
-					\Session::set_flash('error', 'Unable to delete message');
-					\Log::error($e->getMessage().' '.$e->getTraceAsString(), __METHOD__);
+					\Session::set_flash('error', 'Unable to delete message: '.$e->getMessage());
+					\Log::error(
+						'Unable to delete Ticker message #'.$message->id.': '.$e->getMessage().' [Trace: '.$e->getTraceAsString().']',
+						__METHOD__
+					);
 				}
 			}
 			else {

--- a/classes/controller/manage.php
+++ b/classes/controller/manage.php
@@ -93,7 +93,7 @@ class Controller_Manage extends \Cms\Controller_Template
 				}
 				catch (\Exception $e) {
 					\Session::set_flash('error', 'Unable to delete message');
-					\Log::error($e->getMessage().PHP_EOL.$e->getTraceAsString(), __METHOD__);
+					\Log::error($e->getMessage().' '.$e->getTraceAsString(), __METHOD__);
 				}
 			}
 			else {

--- a/classes/controller/manage.php
+++ b/classes/controller/manage.php
@@ -78,24 +78,34 @@ class Controller_Manage extends \Cms\Controller_Template
 	 */
 	public function action_delete($id = false)
 	{
-		$message = \Ticker\Model_Message::find($id);
+		$redirect_url = \Uri::create('/admin/ticker/manage');
 
-		if ($message) {
-			try
-			{
-				$message->delete();
-				\Session::set_flash("success", "Message deleted");
+		// Check if ID is valid
+		if ($id = (int)$id) {
+			// Fetch the ticker message
+			$message = \Ticker\Model_Message::find($id);
 
-				\Response::redirect(\Uri::create("/admin/ticker/manage"));
+			// Check if message is existent (not null)
+			if ($message) {
+				try {
+					$message->delete();
+					\Session::set_flash('success', 'Message deleted');
+				}
+				catch (\Exception $e) {
+					\Session::set_flash('error', 'Unable to delete message');
+					\Log::error($e->getMessage().PHP_EOL.$e->getTraceAsString(), __METHOD__);
+				}
 			}
-			catch(\Exception $e)
-			{
-				\Session::set_flash("Unable to delete message");
+			else {
+				\Session::set_flash('error', 'Message you were trying to delete does not exist');
 			}
 		}
+		else {
+			\Session::set_flash('error', 'Invalid ticker message ID');
+		}
 
-		\Session::set_flash('error', 'Message you were trying to delete does not exist');
-		\Response::redirect(\Uri::create("/admin/ticker/manage"));
+		// We don't want anyone to stay in delete page as it doesn't have any content
+		\Response::redirect($redirect_url);
 	}
 
 	public function action_set_default($id = false)

--- a/classes/controller/manage.php
+++ b/classes/controller/manage.php
@@ -80,18 +80,22 @@ class Controller_Manage extends \Cms\Controller_Template
 	{
 		$message = \Ticker\Model_Message::find($id);
 
-		// try to delete the message
-		try
-		{
-			$message->delete();
-			\Session::set_flash("success", "Message deleted");
+		if ($message) {
+			try
+			{
+				$message->delete();
+				\Session::set_flash("success", "Message deleted");
 
-			\Response::redirect(\Uri::create("/admin/ticker/manage"));
+				\Response::redirect(\Uri::create("/admin/ticker/manage"));
+			}
+			catch(\Exception $e)
+			{
+				\Session::set_flash("Unable to delete message");
+			}
 		}
-		catch(\Exception $e)
-		{
-			\Session::set_flash("Unable to delete message");
-		}
+
+		\Session::set_flash('error', 'Message you were trying to delete does not exist');
+		\Response::redirect(\Uri::create("/admin/ticker/manage"));
 	}
 
 	public function action_set_default($id = false)


### PR DESCRIPTION
NewRelic reported issues. Throws **Oops error** on production if the message you were trying to delete could not be found. Wrapped it up to fail gracefully and raise a notification in that case.

http://control.propeller.me.uk/chc_change_details.asp?changeid=128086